### PR TITLE
Fix depsearch needle/haystack positional argument order

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -44,11 +44,11 @@ const program = new Command();
 
 program.command('depsearch')
     .description('Search for a certain (possibly nested) dependency in a given package')
-    .argument('<haystack>', 'The package to search within, optionally with a given version')
     .argument('<needle>', 'The dependency to search for (all versions will be searched for)')
-    .action(async (haystack: string, needle: string) => {
-        if (typeof haystack !== 'string' || typeof needle !== 'string') {
-            throw new Error('Provide the package to search as the first argument and the target package as the second');
+    .argument('<haystack>', 'The package to search within, optionally with a given version')
+    .action(async (needle: string, haystack: string) => {
+        if (typeof needle !== 'string' || typeof haystack !== 'string') {
+            throw new Error('Provide the package to search for as the first argument, and the package to search within as the second');
         }
 
         const haystackParts = /([^@]+)(?:@(.+))?/.exec(haystack);

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,7 +46,7 @@ program.command('depsearch')
     .description('Search for a certain (possibly nested) dependency in a given package')
     .argument('<haystack>', 'The package to search within, optionally with a given version')
     .argument('<needle>', 'The dependency to search for (all versions will be searched for)')
-    .action(async (needle: string, haystack: string) => {
+    .action(async (haystack: string, needle: string) => {
         if (typeof haystack !== 'string' || typeof needle !== 'string') {
             throw new Error('Provide the package to search as the first argument and the target package as the second');
         }


### PR DESCRIPTION
Two commits in one, so choose your pick! Our suggestion is `<needle> <haystack>`.