### PR TITLE
Improve popular-packages-containing messaging legibility

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -152,7 +152,7 @@ program.command('popular-packages-containing')
             return true;
         });
 
-        console.log(packages.length);
+        console.log(`Checking ${packages.length} popular packages.`);
 
         const afflictedPackages: DepGraph[] = [];
         await Promise.all(packages.map(async (pkg) => {
@@ -167,6 +167,7 @@ program.command('popular-packages-containing')
         }));
 
         for (const dep of afflictedPackages) {
+            console.log('');
             console.log(`${dep.rootManifest.name}:`);
             for (const path of dep.findPathsTo(pkgName)) {
                 console.log(`    ${path.join(' -> ')}`);


### PR DESCRIPTION
Explains `packages.length` and sticks a blank line between each chunk of results.