### PR TITLE
Cache-related fixes

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,10 +1,11 @@
 import 'dotenv/config';
-import {resolve} from 'node:path';
+import {dirname, resolve} from 'node:path';
+import {fileURLToPath} from 'node:url';
 
 export type Config = {
     cacheDir: string;
 };
 
 export const config = {
-    cacheDir: process.env.CACHE_DIR ?? resolve(import.meta.dirname, '..', '_cache'),
+    cacheDir: process.env.CACHE_DIR ?? resolve(dirname(fileURLToPath(import.meta.url)), '..', '_cache'),
 };

--- a/src/ecosyste-ms.ts
+++ b/src/ecosyste-ms.ts
@@ -4,15 +4,26 @@ import {
     getRegistryPackagesResponse,
     getRegistryPackagesResponseItem,
 } from './gen/zod/ecosysteMsPackages.js';
+import {mkdir} from 'node:fs/promises';
 import {stringify} from 'node:querystring';
+import {dirname} from 'node:path';
 import Keyv from 'keyv';
 
 import {config} from './config.js';
 import {z} from 'zod';
 
-const cache = new Keyv(`sqlite://${config.cacheDir}/ecosyste-ms.sqlite`);
+let cache;
+
+async function readyCache() {
+    if (!cache) {
+        await mkdir(config.cacheDir, {recursive: true});
+        cache = new Keyv(`sqlite://${config.cacheDir}/ecosyste-ms.sqlite`);
+    }
+}
 
 export async function fetchDependentPackages(packageName: string, maxResults = 1000) {
+    await readyCache();
+
     const queryString = stringify({
         page: 0,
         per_page: maxResults,
@@ -36,6 +47,8 @@ export async function fetchDependentPackages(packageName: string, maxResults = 1
 }
 
 export async function fetchPopularPackages(maxResults = 1000) {
+    await readyCache();
+
     const queryString = stringify({
         page: 0,
         per_page: maxResults,


### PR DESCRIPTION
Makes locating the default cache work on less than Node 20.11/21.2 (so you can run without providing your own `CACHE_DIR`), and ensures the directory *containing* the cache database file is created before the cache `Keyv` is actually instantiated.

(`Keyv` crashes if the directory doesn't exist. And it *still* crashes on the first run, if we create the directory *after* instantiating `Keyv` - though still before accessing it. Creating the directory before instantiating avoids the crash on first as well as subsequent runs.)