### PR TITLE
Rename popular-reverse-deps to popular-dependents

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ After cloning this repo, run `npm run firebreak -- [args]` to execute the main C
 
 This subcommand allows you to search for a nested dependency within a given package. All versions of the nested dependency will be searched for.
 
-### `popular-reverse-deps`
+### `popular-dependents`
 
-This subcommand allows you to view the most popular reverse dependencies for a given package. Note that the ecosyste.ms API doesn't seem to return accurate results, so this may omit many packages.
+This subcommand allows you to view the most popular dependents for a given package. Note that the ecosyste.ms API doesn't seem to return accurate results, so this may omit many packages.
 
 ### `popular-packages-containing`
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,9 +65,9 @@ program.command('depsearch')
         console.log(tree.findPathsTo(needle));
     });
 
-program.command('popular-reverse-deps')
-    .description('Search for the most popular reverse dependencies of a given package')
-    .argument('<package>', 'The package to search the reverse dependencies of')
+program.command('popular-dependents')
+    .description('Search for the most popular dependents of a given package')
+    .argument('<package>', 'The package to search the dependents of')
     .addOption(new Option(
         '--recent-update [PERIOD]',
         'Only show packages updated this recently (can be specified in "y"ears, "m"onths, "w"eeks, and "d"ays)',
@@ -100,7 +100,7 @@ program.command('popular-reverse-deps')
         });
 
         if (dependents.length === 0) {
-            console.log(`"${pkgName}" doesn't appear to have any popular reverse dependencies.`);
+            console.log(`"${pkgName}" doesn't appear to have any popular dependents.`);
             console.log(`Note that the ecosyste.ms API doesn't seem to return accurate results,`);
             console.log(`so this may omit many packages.`);
             return;

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,6 +66,7 @@ program.command('depsearch')
     });
 
 program.command('popular-dependents')
+    .alias('popular-dependants')
     .description('Search for the most popular dependents of a given package')
     .argument('<package>', 'The package to search the dependents of')
     .addOption(new Option(


### PR DESCRIPTION
Minor caveat of including the `popular-dependants` alias is that, well, it does show up in commander's help screen LOL

```
Commands:
  depsearch <needle> <haystack>                              Search for a certain (possibly nested) dependency in a given package
  popular-dependents|popular-dependants [options] <package>  Search for the most popular dependents of a given package
  popular-packages-containing [options] <package>            Search for popular packages depending on a given package
  help [command]                                             display help for command
```

(Honestly we aren't the biggest fansies of commander in general though, we'll probs figure out a friendlier/sexier CLI frontend a little later)